### PR TITLE
Handle HTTP channels (always respond with a 404)

### DIFF
--- a/session.go
+++ b/session.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"io/ioutil"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func handleSessionChannel(channel ssh.Channel) (string, error) {
+	channelInputBytes, err := ioutil.ReadAll(channel)
+	return string(channelInputBytes), err
+}

--- a/tcpip.go
+++ b/tcpip.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func handleDirectTCPIPChannel(channel ssh.Channel, port uint32) (string, error) {
+	switch port {
+	case 80:
+		return handleHTTPChannel(channel)
+	default:
+		return "", fmt.Errorf("unsupported port %v", port)
+	}
+}
+
+func handleHTTPChannel(channel ssh.Channel) (string, error) {
+	request, err := http.ReadRequest(bufio.NewReader(channel))
+	if err != nil {
+		return "", err
+	}
+	requestBytes, err := httputil.DumpRequest(request, true)
+	if err != nil {
+		return "", err
+	}
+	responseRecorder := httptest.NewRecorder()
+	http.NotFound(responseRecorder, request)
+	if err := responseRecorder.Result().Write(channel); err != nil {
+		return "", err
+	}
+	return string(requestBytes), nil
+}


### PR DESCRIPTION
* Handle `session` and `direct-tcpip` channels separately
* No changes to how session channels are handled
* Handle TCP/IP channels for port 80 as HTTP: parse requests, respond with 404s
* Don't try handling TCP/IP channels for other ports for now