### PR TITLE
Readd optional debug logs, add a test for verifying the sample config

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ type loggingConfig struct {
 	JSON           bool   `yaml:"json"`
 	Timestamps     bool   `yaml:"timestamps"`
 	MetricsAddress string `yaml:"metrics_address"`
+	Debug          bool   `yaml:"debug"`
 }
 
 type commonAuthConfig struct {

--- a/config_test.go
+++ b/config_test.go
@@ -315,3 +315,27 @@ func TestExistingKey(t *testing.T) {
 		t.Errorf("oldKey!=newKey")
 	}
 }
+
+func TestDefaultConfigFile(t *testing.T) {
+	configBytes, err := ioutil.ReadFile("sshesame.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read config file: %v", err)
+	}
+	dataDir := t.TempDir()
+	cfg, err := getConfig(string(configBytes), dataDir)
+	if err != nil {
+		t.Fatalf("Failed to get config: %v", err)
+	}
+
+	// The sample config has example keyboard interactive auth options set.
+	// Since the auth method itself is disabled, this doesn't make a difference.
+	// Unset them so they don't affect the comparison.
+	cfg.Auth.KeyboardInteractiveAuth.Instruction = ""
+	cfg.Auth.KeyboardInteractiveAuth.Questions = nil
+
+	defaultCfg, err := getConfig("", dataDir)
+	if err != nil {
+		t.Fatalf("Failed to get default config: %v", err)
+	}
+	verifyConfig(t, cfg, defaultCfg)
+}

--- a/connection.go
+++ b/connection.go
@@ -86,6 +86,11 @@ func handleConnection(conn net.Conn, cfg *config) {
 				requests = nil
 				continue
 			}
+			context.logEvent(debugGlobalRequestLog{
+				RequestType: request.Type,
+				WantReply:   request.WantReply,
+				Payload:     string(request.Payload),
+			})
 			if err := handleGlobalRequest(request, &context); err != nil {
 				warningLogger.Printf("Failed to handle global request: %v", err)
 				requests = nil
@@ -96,6 +101,11 @@ func handleConnection(conn net.Conn, cfg *config) {
 				newChannels = nil
 				continue
 			}
+			context.logEvent(debugChannelLog{
+				channelLog:  channelLog{ChannelID: channelID},
+				ChannelType: newChannel.ChannelType(),
+				ExtraData:   string(newChannel.ExtraData()),
+			})
 			channelType := newChannel.ChannelType()
 			handler := channelHandlers[channelType]
 			if handler == nil {

--- a/logging.go
+++ b/logging.go
@@ -287,6 +287,12 @@ func (entry windowChangeLog) eventType() string {
 	return "window_change"
 }
 
+type debugGlobalRequestLog struct {
+	RequestType string `json:"request_type"`
+	WantReply   bool   `json:"want_reply"`
+	Payload     string `json:"payload"`
+}
+
 func (context connContext) logEvent(entry logEntry) {
 	if context.cfg.Logging.JSON {
 		var jsonEntry interface{}

--- a/logging.go
+++ b/logging.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -293,7 +294,59 @@ type debugGlobalRequestLog struct {
 	Payload     string `json:"payload"`
 }
 
+func (entry debugGlobalRequestLog) String() string {
+	jsonBytes, err := json.Marshal(entry)
+	if err != nil {
+		warningLogger.Printf("Failed to log event: %v", err)
+		return ""
+	}
+	return fmt.Sprintf("DEBUG global request received: %v\n", string(jsonBytes))
+}
+func (entry debugGlobalRequestLog) eventType() string {
+	return "debug_global_request"
+}
+
+type debugChannelLog struct {
+	channelLog
+	ChannelType string `json:"channel_type"`
+	ExtraData   string `json:"extra_data"`
+}
+
+func (entry debugChannelLog) String() string {
+	jsonBytes, err := json.Marshal(entry)
+	if err != nil {
+		warningLogger.Printf("Failed to log event: %v", err)
+		return ""
+	}
+	return fmt.Sprintf("DEBUG new channel requested: %v\n", string(jsonBytes))
+}
+func (entry debugChannelLog) eventType() string {
+	return "debug_channel"
+}
+
+type debugChannelRequestLog struct {
+	channelLog
+	RequestType string `json:"request_type"`
+	WantReply   bool   `json:"want_reply"`
+	Payload     string `json:"payload"`
+}
+
+func (entry debugChannelRequestLog) String() string {
+	jsonBytes, err := json.Marshal(entry)
+	if err != nil {
+		warningLogger.Printf("Failed to log event: %v", err)
+		return ""
+	}
+	return fmt.Sprintf("DEBUG channel request received: %v\n", string(jsonBytes))
+}
+func (entry debugChannelRequestLog) eventType() string {
+	return "debug_channel_request"
+}
+
 func (context connContext) logEvent(entry logEntry) {
+	if strings.HasPrefix(entry.eventType(), "debug_") && !context.cfg.Logging.Debug {
+		return
+	}
 	if context.cfg.Logging.JSON {
 		var jsonEntry interface{}
 		if context.cfg.Logging.Timestamps {

--- a/session.go
+++ b/session.go
@@ -396,6 +396,12 @@ func handleSessionChannel(newChannel ssh.NewChannel, context channelContext) err
 				}
 				continue
 			}
+			context.logEvent(debugChannelRequestLog{
+				channelLog:  channelLog{ChannelID: context.channelID},
+				RequestType: request.Type,
+				WantReply:   request.WantReply,
+				Payload:     string(request.Payload),
+			})
 			if err := session.handleRequest(request); err != nil {
 				return err
 			}

--- a/tcpip.go
+++ b/tcpip.go
@@ -113,6 +113,12 @@ func handleDirectTCPIPChannel(newChannel ssh.NewChannel, context channelContext)
 				continue
 			}
 			tcpipChannelRequestsMetric.WithLabelValues("unknown").Inc()
+			context.logEvent(debugChannelRequestLog{
+				channelLog:  channelLog{ChannelID: context.channelID},
+				RequestType: request.Type,
+				WantReply:   request.WantReply,
+				Payload:     string(request.Payload),
+			})
 			warningLogger.Printf("Unsupported direct-tcpip request type %v", request.Type)
 			if request.WantReply {
 				if err := request.Reply(false, nil); err != nil {


### PR DESCRIPTION
Debug logs could be useful even though the original use case (automatic replay tests) doesn't require them anymore.
The new test will ensure that the sample config is always kept up to date.

Fixes https://github.com/jaksi/sshesame/issues/71