### PR TITLE
Release, readme and flag fixes

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -15,10 +15,16 @@ jobs:
         env:
           GOOS: linux
           GOARCH: amd64
-      - run: go build -o sshesame-linux-arm
+      - run: go build -o sshesame-linux-armv6
         env:
           GOOS: linux
           GOARCH: arm
+          GOARM: 6
+      - run: go build -o sshesame-linux-armv7
+        env:
+          GOOS: linux
+          GOARCH: arm
+          GOARM: 7
       - run: go build -o sshesame-linux-arm64
         env:
           GOOS: linux
@@ -35,10 +41,11 @@ jobs:
         env:
           GOOS: windows
           GOARCH: amd64
-      - run: go build -o sshesame-windows-arm.exe
+      - run: go build -o sshesame-windows-armv7.exe
         env:
           GOOS: windows
           GOARCH: arm
+          GOARM: 7
       - run: go build -o sshesame-windows-arm64.exe
         env:
           GOOS: windows
@@ -47,11 +54,12 @@ jobs:
         with:
           files: |
             sshesame-linux-amd64
-            sshesame-linux-arm
+            sshesame-linux-armv6
+            sshesame-linux-armv7
             sshesame-linux-arm64
             sshesame-macos-amd64
             sshesame-macos-arm64
             sshesame-windows-amd64.exe
-            sshesame-windows-arm.exe
+            sshesame-windows-armv7.exe
             sshesame-windows-arm64.exe
             sshesame.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang as build-env
 WORKDIR /go/src/sshesame
 ADD . /go/src/sshesame
-RUN go get -d
 RUN go build -o /go/bin/sshesame
 RUN sed -i 's/listen_address: .*/listen_address: 0.0.0.0:2022/' sshesame.yaml
 FROM gcr.io/distroless/base

--- a/README.md
+++ b/README.md
@@ -8,34 +8,74 @@ An easy to set up and use SSH honeypot, a fake SSH server that lets anyone in an
 
 ## Installation and usage
 
-### GitHub release
-
-Binaries are built and released automatically and are available on the [releases page](https://github.com/jaksi/sshesame/releases).
-
 ### From source
 
+```shell
+$ git clone https://github.com/jaksi/sshesame.git
+$ cd sshesame
+$ go build
 ```
-go get github.com/jaksi/sshesame
-sshesame [-config sshesame.yaml] [-data_dir /etc/sshesame]
+
+### GitHub releases
+
+Linux, macOS and Windows binaries for several architectures are built and released automatically and are available on the [Releases page](https://github.com/jaksi/sshesame/releases).
+
+### Usage
+
+```shell
+$ sshesame -h
+Usage of sshesame:
+  -config string
+    	optional config file
+  -data_dir string
+    	data directory to store automatically generated host keys in (default "...")
 ```
+
+Debug and error logs are written to standard error. Activity logs by default are written to standard out, unless the `logging.file` config option is set.
 
 ### Docker
 
-Images are automatically published to [GitHub Packages](https://github.com/jaksi/sshesame/pkgs/container/sshesame).
+Images for amd64, arm64 and armv7 are built and published automatically and are available on the [Packages page](https://github.com/jaksi/sshesame/pkgs/container/sshesame).
 
+#### CLI
+
+```shell
+$ docker run -it --rm\
+    -p 127.0.0.1:2022:2022\
+    -v sshesame-data:/data\
+    [-v $PWD/sshesame.yaml:/config.yaml]\
+    ghcr.io/jaksi/sshesame
 ```
-docker run -it --rm -p 127.0.0.1:2022:2022 -v sshesame-data:/data [-v $PWD/sshesame.yaml:/config.yaml] ghcr.io/jaksi/sshesame
+
+#### Dockerfile
+
+```dockerfile
+FROM ghcr.io/jaksi/sshesame
+#COPY sshesame.yaml /config.yaml
+```
+
+#### Docker Compose
+
+```yaml
+services:
+  sshesame:
+    image: ghcr.io/jaksi/sshesame
+    ports:
+      - "127.0.0.1:2022:2022"
+    volumes:
+      - sshesame-data:/data
+      #- ./sshesame.yaml:/config.yaml
+volumes:
+  sshesame-data: {}
 ```
 
 ### Configuration
 
 A configuration file can optionally be passed using the `-config` flag.
-Without specifying one, sane defaults will be used and RSA, ECDSA and Ed25519 host keys will be generated and stored in the directory specified in the `-data_dir` flag.
+Without specifying one, sane defaults will be used and an RSA, ECDSA and Ed25519 host key will be generated and stored in the directory specified in the `-data_dir` flag.
 
-A [sample configuration file](sshesame.yaml) with explanations for the configuration options is included.
+A [sample configuration file](sshesame.yaml) with default settings and explanations for all configuration options is included.  
 A [minimal configuration file](openssh.yaml) which tries to mimic an OpenSSH server is also included.
-
-Debug and error logs are written to standard error. Activity logs by default are written to standard out, unless the `logging.file` config option is set.
 
 ## Sample output
 

--- a/main.go
+++ b/main.go
@@ -26,8 +26,8 @@ func init() {
 }
 
 func main() {
-	configFile := flag.String("config", "", "config file")
-	dataDir := flag.String("data_dir", path.Join(xdg.DataHome, "sshesame"), "data directory")
+	configFile := flag.String("config", "", "optional config file")
+	dataDir := flag.String("data_dir", path.Join(xdg.DataHome, "sshesame"), "data directory to store automatically generated host keys in")
 	flag.Parse()
 
 	configString := ""


### PR DESCRIPTION
* Build for linux/armv6, linux/armv7 and windows/armv7
* Remove unneeded `go get` from the Dockerfile
* Restructure and expand the readme
* Expand the description for command line flags