### PR TITLE
Add support for multiple listen addresses

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,9 +20,10 @@ import (
 )
 
 type serverConfig struct {
-	ListenAddress string            `yaml:"listen_address"`
-	HostKeys      []string          `yaml:"host_keys"`
-	TCPIPServices map[uint32]string `yaml:"tcpip_services"`
+	ListenAddress   string            `yaml:"listen_address"`
+	ListenAddresses []string          `yaml:"listen_addresses"`
+	HostKeys        []string          `yaml:"host_keys"`
+	TCPIPServices   map[uint32]string `yaml:"tcpip_services"`
 }
 
 type loggingConfig struct {

--- a/config_test.go
+++ b/config_test.go
@@ -481,3 +481,23 @@ server:
 		t.Errorf("len(cfg.Server.TCPIPServices)=%d, want 0", len(cfg.Server.TCPIPServices))
 	}
 }
+
+func TestMultipleListenAddresses(t *testing.T) {
+	cfgString := `
+server:
+  listen_addresses:
+    - 127.0.0.1:22
+    - "[::1]:22"
+`
+	dataDir := t.TempDir()
+	cfg := &config{}
+	err := cfg.load(cfgString, dataDir)
+	if err != nil {
+		t.Fatalf("Failed to get config: %v", err)
+	}
+
+	expectedListenAddresses := []string{"127.0.0.1:22", "[::1]:22"}
+	if !reflect.DeepEqual(cfg.Server.ListenAddresses, expectedListenAddresses) {
+		t.Errorf("Server.ListenAddresses=%v, want %v", cfg.Server.ListenAddresses, expectedListenAddresses)
+	}
+}

--- a/sshesame.yaml
+++ b/sshesame.yaml
@@ -1,6 +1,12 @@
 server:
   listen_address: 127.0.0.1:2022
 
+  # To listen on multiple addresses instead use
+  #
+  #listen_addresses:
+  #  - 127.0.0.1:2022
+  #  - "[::1]:2022"
+
   # Host private key files.
   # If unspecified, null or empty, an RSA, ECDSA and Ed25519 key will be generated and stored.
   host_keys: null


### PR DESCRIPTION
My usecase requires listening on multiple addresses at once, and it's easier to do if sshesame itself supports it

Test:
```
INFO 2025/05/07 22:03:14 Listening on 127.0.0.1:2022
INFO 2025/05/07 22:03:14 Listening on [::1]:2022
2025/05/07 22:03:37 [127.0.0.1:47262] authentication for user "root" without credentials rejected
2025/05/07 22:03:46 [127.0.0.1:47262] authentication for user "root" with password "rootv4" accepted
2025/05/07 22:03:46 [127.0.0.1:47262] connection with client version "SSH-2.0-OpenSSH_9.9" established
2025/05/07 22:03:46 [127.0.0.1:47262] [channel 0] session requested
2025/05/07 22:03:46 [127.0.0.1:47262] [channel 0] PTY using terminal "tmux-256color" (size 188x21) requested
2025/05/07 22:03:46 [127.0.0.1:47262] [channel 0] shell requested
2025/05/07 22:03:54 [127.0.0.1:47262] [channel 0] input: "echo \"this is ipv4\""
2025/05/07 22:04:06 [[::1]:40720] authentication for user "root" without credentials rejected
2025/05/07 22:04:10 [[::1]:40720] authentication for user "root" with password "rootv6" accepted
2025/05/07 22:04:10 [[::1]:40720] connection with client version "SSH-2.0-OpenSSH_9.9" established
2025/05/07 22:04:10 [[::1]:40720] [channel 0] session requested
2025/05/07 22:04:10 [[::1]:40720] [channel 0] PTY using terminal "tmux-256color" (size 188x21) requested
2025/05/07 22:04:10 [[::1]:40720] [channel 0] shell requested
2025/05/07 22:04:16 [[::1]:40720] [channel 0] input: "echo \"this is ipv6\""
2025/05/07 22:04:20 [[::1]:40720] [channel 0] closed
2025/05/07 22:04:20 [[::1]:40720] connection closed
2025/05/07 22:04:22 [127.0.0.1:47262] [channel 0] closed
2025/05/07 22:04:22 [127.0.0.1:47262] connection closed
```